### PR TITLE
fix: adding default to NUM_NWAKU_NODES in traffic script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       dockerfile: Dockerfile.rest-traffic
     command: >
       python /opt/traffic.py
-      --multiple-nodes=http://waku-simulator_nwaku_[1..$NUM_NWAKU_NODES]:8645
+      --multiple-nodes=http://waku-simulator_nwaku_[1..${NUM_NWAKU_NODES:-5}]:8645
       --msg-size-kbytes=${MSG_SIZE_KBYTES:-10}
       --delay-seconds=${TRAFFIC_DELAY_SECONDS:-15}
     volumes:


### PR DESCRIPTION
Default value for NUM_NWAKU_NODES when running the traffic script was missing