### PR TITLE
chore: adding libp2p stream direction to dashboard

### DIFF
--- a/monitoring/configuration/dashboards/nwaku-monitoring.json
+++ b/monitoring/configuration/dashboards/nwaku-monitoring.json
@@ -201,7 +201,7 @@
           },
           "editorMode": "code",
           "expr": "libp2p_open_streams{instance=\"[[nwaku_instance]]\"}",
-          "legendFormat": "{{instance}}_{{type}}",
+          "legendFormat": "{{instance}}_{{type}}_{{dir}}",
           "range": true,
           "refId": "A"
         }


### PR DESCRIPTION
Showing the direction of libp2p open streams in Grafana dashboard