### PR TITLE
Add grafana dashboard panel for RLN invalid messages

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     environment:
       - RPC_URL=${RPC_URL:-http://foundry:8545}
     entrypoint: sh
-    command: 
+    command:
       - '/opt/deploy_rln_contract.sh'
     volumes:
       - ./deploy_rln_contract.sh:/opt/deploy_rln_contract.sh
@@ -63,7 +63,7 @@ services:
       - ./run_bootstrap.sh:/opt/run_bootstrap.sh:Z
     networks:
       - simulation
-  
+
   nwaku:
     image: ${NWAKU_IMAGE:-wakuorg/nwaku:latest}
     restart: on-failure
@@ -145,9 +145,7 @@ services:
       - ./monitoring/configuration/customizations/custom-logo.svg:/usr/share/grafana/public/img/grafana_typelogo.svg:z
       - ./monitoring/configuration/customizations/custom-logo.png:/usr/share/grafana/public/img/fav32.png:z
     ports:
-      #- 127.0.0.1:3000:3000
-      # open port to access the dashboard
-      - 3000:3000
+      - 0.0.0.0:3001:3001
     restart: on-failure
     depends_on:
       - prometheus
@@ -190,12 +188,12 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
     depends_on:
-      - redis 
+      - redis
       - mongodb
       - foundry
     networks:
       - simulation
-  
+
   mongodb:
     image: mongo:5.0.8
     environment:
@@ -208,7 +206,7 @@ services:
   web:
     image: web3labs/epirus-free-web:latest
     ports:
-      - 0.0.0.0:3001:3000
+      - 0.0.0.0:3000:3000
     environment:
       - API_URL=http://localhost:8090
       - WS_API_URL=ws://localhost:8090
@@ -217,7 +215,7 @@ services:
       - api
     networks:
       - simulation
-  
+
   ingestion:
     image: web3labs/epirus-free-ingestion:latest
     environment:

--- a/monitoring/configuration/dashboards/nwaku-monitoring.json
+++ b/monitoring/configuration/dashboards/nwaku-monitoring.json
@@ -4803,6 +4803,103 @@
       ],
       "title": "RLN Valid Messages Total",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 11,
+        "x": 0,
+        "y": 173
+      },
+      "id": 82,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "waku_rln_invalid_messages_total_total",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{instance}}_{{__name__}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "RLN Invalid Messages Total",
+      "type": "timeseries"
     }
   ],
   "refresh": "10s",

--- a/monitoring/configuration/grafana.ini
+++ b/monitoring/configuration/grafana.ini
@@ -1,5 +1,8 @@
 instance_name = nwaku dashboard
 
+[server]
+http_port = 3001
+
 ;[dashboards.json]
 ;enabled = true
 ;path = /home/git/grafana/grafana-dashboards/dashboards

--- a/wakusim.env
+++ b/wakusim.env
@@ -2,7 +2,7 @@
 NWAKU_IMAGE=wakuorg/nwaku:latest
 GOWAKU_IMAGE=wakuorg/go-waku:v0.8.0
 # Network scaling.
-NUM_NWAKU_NODES=10
+NUM_NWAKU_NODES=50
 NUM_GOWAKU_NODES=0
 # Simulation traffic.
 MSG_PER_SECOND=10


### PR DESCRIPTION
This PR:
1. Adds a panel to the grafana dashboard to monitor the `waku_rln_invalid_messages_total_total` metric.
2. Updates the docker-compose file with the port changes made on deploy-wakusim.