### PR TITLE
Fix discv5 problem with correct config

### DIFF
--- a/run_nwaku.sh
+++ b/run_nwaku.sh
@@ -78,6 +78,8 @@ exec /usr/bin/wakunode\
       --rest-admin=true\
       --rest-private=true\
       --rest-address=0.0.0.0\
+      --cluster-id=0\
+      --pubsub-topic=/waku/2/default-waku/proto\
       --rln-relay=true\
       --rln-relay-dynamic=true\
       --rln-relay-eth-client-address="$RPC_URL"\


### PR DESCRIPTION
* Fixes the problem with peer discovery, where discv5 couldn't locate other peers.
* This was caused due to a missing configuration.
* This PR fixes it.
* Note that once https://github.com/waku-org/nwaku/pull/2562 is merged, this config won't be needed anymore (but also doesn't harm).