### PR TITLE
Update nwaku log level

### DIFF
--- a/run_nwaku.sh
+++ b/run_nwaku.sh
@@ -89,7 +89,7 @@ exec /usr/bin/wakunode\
       --dns-discovery=true\
       --discv5-discovery=true\
       --discv5-enr-auto-update=True\
-      --log-level=INFO\
+      --log-level=DEBUG\
       --metrics-server=True\
       --metrics-server-address=0.0.0.0\
       --discv5-bootstrap-node=${BOOTSTRAP_ENR}\


### PR DESCRIPTION
This PR updates the run_nwaku script to change the log level to DEBUG.
We need this in order to gain more information as to why the nodes cannot connect to each other on infra's host.