### PR TITLE
Update nwaku image variable to latest

### DIFF
--- a/wakusim.env
+++ b/wakusim.env
@@ -1,8 +1,8 @@
 # Env variables for metal-01.he-eu-hel1.wakusim.misc host.
-NWAKU_IMAGE=harbor.status.im/wakuorg/nwaku@sha256:501cbf36f2e4856848102cccd983f003372ce6fd7c17eba36ae8906deb2e03d8
+NWAKU_IMAGE=harbor.status.im/wakuorg/nwaku@sha256:latest
 GOWAKU_IMAGE=wakuorg/go-waku:v0.8.0
 # Network scaling.
-NUM_NWAKU_NODES=50
+NUM_NWAKU_NODES=10
 NUM_GOWAKU_NODES=0
 # Simulation traffic.
 MSG_PER_SECOND=10

--- a/wakusim.env
+++ b/wakusim.env
@@ -1,5 +1,5 @@
 # Env variables for metal-01.he-eu-hel1.wakusim.misc host.
-NWAKU_IMAGE=harbor.status.im/wakuorg/nwaku@sha256:latest
+NWAKU_IMAGE=harbor.status.im/wakuorg/nwaku:latest
 GOWAKU_IMAGE=wakuorg/go-waku:v0.8.0
 # Network scaling.
 NUM_NWAKU_NODES=10


### PR DESCRIPTION
This PR updates the wakusim.env file to use the latest nwaku image.
The total nwaku nodes are decreased from 10 to 50 to check whether it works for fewer nodes.