### PR TITLE
Remove gowaku parameters from wakusim.env

### DIFF
--- a/wakusim.env
+++ b/wakusim.env
@@ -1,9 +1,7 @@
 # Env variables for metal-01.he-eu-hel1.wakusim.misc host.
 NWAKU_IMAGE=wakuorg/nwaku:latest
-GOWAKU_IMAGE=wakuorg/go-waku:v0.8.0
 # Network scaling.
 NUM_NWAKU_NODES=50
-NUM_GOWAKU_NODES=0
 # Simulation traffic.
 MSG_PER_SECOND=10
 MSG_SIZE_KBYTES=10


### PR DESCRIPTION
This PR removes the last of the gowaku parameters present in the repo.