### PR TITLE
Add nwaku start dependency condition

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,8 +83,8 @@ services:
     volumes:
       - ./run_nwaku.sh:/opt/run_nwaku.sh:Z
     depends_on:
-      - bootstrap
-      - contract-repo-deployer
+      contract-repo-deployer:
+        condition: service_completed_successfully
     networks:
       - simulation
       


### PR DESCRIPTION
This PR addresses issue https://github.com/waku-org/waku-simulator/issues/36
A dependency condition is added to the nwaku service in docker-compose to wait for the completion of the contract deployment service.