### PR TITLE
Add pubsub-topic and cluster-id config to fix peer connectivity

### DIFF
--- a/run_bootstrap.sh
+++ b/run_bootstrap.sh
@@ -23,4 +23,6 @@ exec /usr/bin/wakunode\
       --rest=true\
       --rest-admin=true\
       --rest-private=true\
-      --rest-address=0.0.0.0
+      --rest-address=0.0.0.0\
+      --pubsub-topic=/waku/2/rs/66/0\
+      --cluster-id=66

--- a/run_nwaku.sh
+++ b/run_nwaku.sh
@@ -91,4 +91,6 @@ exec /usr/bin/wakunode\
       --metrics-server=True\
       --metrics-server-address=0.0.0.0\
       --discv5-bootstrap-node=${BOOTSTRAP_ENR}\
-      --nat=extip:${IP}
+      --nat=extip:${IP}\
+      --pubsub-topic=/waku/2/rs/66/0\
+      --cluster-id=66


### PR DESCRIPTION
This PR fixes the peer connectivity issue observed after nwaku changes.
It adds a pubsub-topic and cluster-id to the following scripts:
- run_bootstrap
- run_nwaku
