### PR TITLE
fix: updating pubsub topic in traffic generator

### DIFF
--- a/traffic.py
+++ b/traffic.py
@@ -49,7 +49,7 @@ group.add_argument('-mn', '--multiple-nodes', type=str, help='example: http://wa
 
 # rest of araguments
 parser.add_argument('-c', '--content-topic', type=str, help='content topic', default="my-ctopic")
-parser.add_argument('-p', '--pubsub-topic', type=str, help='pubsub topic', default="/waku/2/default-waku/proto")
+parser.add_argument('-p', '--pubsub-topic', type=str, help='pubsub topic', default="/waku/2/rs/66/0")
 parser.add_argument('-s', '--msg-size-kbytes', type=int, help='message size in kBytes', default=10)
 parser.add_argument('-d', '--delay-seconds', type=int, help='delay in second between messages', required=15)
 args = parser.parse_args()


### PR DESCRIPTION
After https://github.com/waku-org/waku-simulator/commit/a802c8b8523e9e60915274815640a237268b5add , nodes aren't subscribed anymore to the pubsub topic of the messages sent in the traffic generator.

Updating the traffic generator to send messages to `/waku/2/rs/66/0`