### PR TITLE
Fix for remote host deployment issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ networks:
       ipam:
           driver: default
           config:
-              - subnet: "10.1.0.0/22"
+              - subnet: "20.1.0.0/22"
 
 services:
 


### PR DESCRIPTION
This PR is a fix for the issue where nodes on a remote host cannot connect to peers. (https://github.com/status-im/infra-misc/issues/268)
On remote hosts using the `10.1.0.0` subnet causes issues.
This PR changes the subnet to `20.1.0.0`