### PR TITLE
Add new grafana admin login credentials

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,6 +121,8 @@ services:
     image: grafana/grafana:latest
     env_file:
       - ./monitoring/configuration/grafana-plugins.env
+    environment:
+      - ADMIN_PASSW=${GF_SECURITY_ADMIN_PASSWORD}
     volumes:
       - ./monitoring/configuration/grafana.ini:/etc/grafana/grafana.ini:z
       - ./monitoring/configuration/dashboards.yaml:/etc/grafana/provisioning/dashboards/dashboards.yaml:z

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,8 @@ services:
     env_file:
       - ./monitoring/configuration/grafana-plugins.env
     environment:
-      - ADMIN_PASSW=${GF_SECURITY_ADMIN_PASSWORD}
+      - GF_SECURITY_ADMIN_USER=${GF_SECURITY_ADMIN_USER}
+      - GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD}
     volumes:
       - ./monitoring/configuration/grafana.ini:/etc/grafana/grafana.ini:z
       - ./monitoring/configuration/dashboards.yaml:/etc/grafana/provisioning/dashboards/dashboards.yaml:z

--- a/monitoring/configuration/grafana.ini
+++ b/monitoring/configuration/grafana.ini
@@ -25,8 +25,8 @@ enabled = true
 org_role = Viewer
 
 [security]
-admin_user = waku
-admin_password = Waku-Waku-eh-eh
+admin_user = wakusim-user
+admin_password = ${ADMIN_PASSW}
 
 ;[users]
 # disable user signup / registration

--- a/monitoring/configuration/grafana.ini
+++ b/monitoring/configuration/grafana.ini
@@ -24,9 +24,9 @@ enabled = true
 ; org_role = Admin
 org_role = Viewer
 
-;[security]
-;admin_user = ocr
-;admin_password = ocr
+[security]
+admin_user = waku
+admin_password = Waku-Waku-eh-eh
 
 ;[users]
 # disable user signup / registration

--- a/monitoring/configuration/grafana.ini
+++ b/monitoring/configuration/grafana.ini
@@ -24,9 +24,9 @@ enabled = true
 ; org_role = Admin
 org_role = Viewer
 
-[security]
-admin_user = admin
-admin_password = admin
+;[security]
+;admin_user = ocr
+;admin_password = ocr
 
 ;[users]
 # disable user signup / registration

--- a/monitoring/configuration/grafana.ini
+++ b/monitoring/configuration/grafana.ini
@@ -25,8 +25,8 @@ enabled = true
 org_role = Viewer
 
 [security]
-admin_user = wakusim-user
-admin_password = ${ADMIN_PASSW}
+admin_user = admin
+admin_password = admin
 
 ;[users]
 # disable user signup / registration


### PR DESCRIPTION
This PR is to fix a vulnerability where the grafana credentials were the default admin/admin.
It addresses this issue https://github.com/waku-org/waku-simulator/issues/55.
The password can be set in the environment variables and for the remote host deployment the password is set in https://github.com/status-im/infra-misc/blob/master/ansible/group_vars/wakusim.yml