### PR TITLE
Update contract limit and rest traffic commit

### DIFF
--- a/deploy_rln_contract.sh
+++ b/deploy_rln_contract.sh
@@ -16,7 +16,7 @@ fi
 cd /waku-rlnv2-contract
 
 #3. Replace the hardcoded MAX_MESSAGE_LIMIT
-sed -i "s/\b20\b/${MAX_MESSAGE_LIMIT}/g" script/Deploy.s.sol
+sed -i "s/\b100\b/${MAX_MESSAGE_LIMIT}/g" script/Deploy.s.sol
 
 # 4. Compile
 echo "forge install..."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,7 +98,7 @@ services:
       - simulation
       
   rest-traffic:
-    image: alrevuelta/rest-traffic:d936446
+    image: alrevuelta/rest-traffic:6992bb5
     command:
       --multiple-nodes=http://waku-simulator_nwaku_[1..${NUM_NWAKU_NODES:-5}]:8645
       --msg-size-kbytes=${MSG_SIZE_KBYTES:-10}


### PR DESCRIPTION
This PR makes updates due to changes in dependencies.
- change in `deploy_rln_contract.sh` due to waku-rln-contract updated hardcoded MAX_MESSAGE_LIMIT
- rest-traffic image commit version update