### PR TITLE
Simplify bootstrap node config

### DIFF
--- a/run_bootstrap.sh
+++ b/run_bootstrap.sh
@@ -5,7 +5,7 @@ IP=$(ip a | grep "inet " | grep -Fv 127.0.0.1 | sed 's/.*inet \([^/]*\).*/\1/')
 echo "I am a bootstrap node"
 
 exec /usr/bin/wakunode\
-      --relay=true\
+      --relay=false\
       --rest=true\
       --rest-admin=true\
       --rest-private=true\
@@ -20,9 +20,5 @@ exec /usr/bin/wakunode\
       --metrics-server-address=0.0.0.0\
       --nodekey=30348dd51465150e04a5d9d932c72864c8967f806cce60b5d26afeca1e77eb68\
       --nat=extip:${IP}\
-      --rest=true\
-      --rest-admin=true\
-      --rest-private=true\
-      --rest-address=0.0.0.0\
       --pubsub-topic=/waku/2/rs/66/0\
       --cluster-id=66

--- a/run_bootstrap.sh
+++ b/run_bootstrap.sh
@@ -10,7 +10,6 @@ exec /usr/bin/wakunode\
       --rest-admin=true\
       --rest-private=true\
       --rest-address=0.0.0.0\
-      --keep-alive=true\
       --max-connections=300\
       --dns-discovery=true\
       --discv5-discovery=true\


### PR DESCRIPTION
* Remove all unnecessary config from the bootstrap node.
* The bootstrap node will now only serve as a discv5 node.
* Closes https://github.com/waku-org/waku-simulator/issues/53