### PR TITLE
Remove deprecated rest-admin and rest-private node config

### DIFF
--- a/run_bootstrap.sh
+++ b/run_bootstrap.sh
@@ -7,8 +7,6 @@ echo "I am a bootstrap node"
 exec /usr/bin/wakunode\
       --relay=false\
       --rest=true\
-      --rest-admin=true\
-      --rest-private=true\
       --rest-address=0.0.0.0\
       --max-connections=300\
       --dns-discovery=true\

--- a/run_nwaku.sh
+++ b/run_nwaku.sh
@@ -136,8 +136,6 @@ exec /usr/bin/wakunode\
       --lightpush=true\
       --max-connections=250\
       --rest=true\
-      --rest-admin=true\
-      --rest-private=true\
       --rest-address=0.0.0.0\
       --rest-port=8645\
       --rln-relay=true\


### PR DESCRIPTION
This PR is to remove deprecated config that breaks the deployment.
- removed config from run_bootstrap.sh
- removed config from run_nwaku.sh