### PR TITLE
chore: Replace pubsubtopic config with shards

### DIFF
--- a/run_bootstrap.sh
+++ b/run_bootstrap.sh
@@ -17,5 +17,4 @@ exec /usr/bin/wakunode\
       --metrics-server-address=0.0.0.0\
       --nodekey=30348dd51465150e04a5d9d932c72864c8967f806cce60b5d26afeca1e77eb68\
       --nat=extip:${IP}\
-      --pubsub-topic=/waku/2/rs/66/0\
       --cluster-id=66

--- a/run_nwaku.sh
+++ b/run_nwaku.sh
@@ -148,5 +148,5 @@ exec /usr/bin/wakunode\
       --metrics-server-address=0.0.0.0\
       --discv5-bootstrap-node=${BOOTSTRAP_ENR}\
       --nat=extip:${IP}\
-      --pubsub-topic=/waku/2/rs/66/0\
+      --shard=0\
       --cluster-id=66


### PR DESCRIPTION
This PR is to update the bootstrap and nwaku config to use shards instead of pubsubtopic.
Pubsub topic has been deprecated in nwaku..