### PR TITLE
fix: Update contract-repo-deployer docker image to match tools glibc version on requirement (Debian 11 -> 12)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - simulation
 
   contract-repo-deployer:
-    image: node:hydrogen-bullseye
+    image: node:hydrogen-bookworm
     labels:
       com.centurylinklabs.watchtower.enable: '${WATCHTOWER_ENABLED:-false}'
     environment:

--- a/run_bootstrap.sh
+++ b/run_bootstrap.sh
@@ -7,6 +7,7 @@ echo "I am a bootstrap node"
 exec /usr/bin/wakunode\
       --relay=false\
       --rest=true\
+      --rest-admin=true\
       --rest-address=0.0.0.0\
       --max-connections=300\
       --dns-discovery=true\


### PR DESCRIPTION
# Description
Seems forge and other tools are updated recently thus fails under Debian11 (node:hydrogen-bullseye) due to missing GLIBC 2.36 version.

### Resolution
- contract-repo-deployer's image is update to Debian12 (node:hydrogen-bookworm)

#### Additional change:
- Enabled rest-admin endpoints on bootstrap node to get access to /admin/v1/peers/...