### PR TITLE
chore: depr rln-relay-tree-path

### DIFF
--- a/run_nwaku.sh
+++ b/run_nwaku.sh
@@ -139,7 +139,6 @@ exec /usr/bin/wakunode\
       --rln-relay-eth-contract-address=$RLN_CONTRACT_ADDRESS\
       --rln-relay-cred-path=$RLN_CREDENTIAL_PATH\
       --rln-relay-cred-password=$RLN_CREDENTIAL_PASSWORD\
-      --rln-relay-tree-path="rlnv2_tree1"\
       --rln-relay-epoch-sec=$RLN_RELAY_EPOCH_SEC\
       --rln-relay-user-message-limit=$RLN_RELAY_MSG_LIMIT\
       --rln-relay-chain-id=1234\


### PR DESCRIPTION
The waku network no longer requires a local rln_tree for syncing the current state. It now relies on the smart contract, so the `rln-relay-tree-path` config is no longer needed.